### PR TITLE
Fix nginx log volume path

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -52,3 +52,4 @@ http {
     scgi_temp_path /tmp/scgi 1 2;
 }
 daemon off;
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         condition: service_healthy
     volumes:
       - cachet_storage:/var/www/html/storage
-      - nginx_logs:/var/log/ngin
+      - nginx_logs:/var/log/nginx
 
   db:
     image: mysql:8.0


### PR DESCRIPTION
## Summary
- fix nginx log volume path in docker compose
- add trailing newline to nginx.conf

## Testing
- `docker-compose config` *(fails: command not found)*
- `pip install pyyaml` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a9e4ff450832f8ee753d24b81bf56